### PR TITLE
change to support mpd without SegmentTemplate tag and use BaseURL wit…

### DIFF
--- a/dashproxy.py
+++ b/dashproxy.py
@@ -321,9 +321,14 @@ class DashDownloader(HasLogger):
             media_template = media_template.replace("$", "}", 1)
             media_template = media_template.replace("%", ":", 1)
 
-            fTimescale = (int)(segment_template_from_adapt.attrib.get('timescale', '1'))
-            fDuration = (int)(segment_template_from_adapt.attrib.get('duration', '1'))
-            fStartNumber = (int)(segment_template_from_adapt.attrib.get('startNumber', '1'))
+            fTimescale = 1
+            fDuration = 1
+            fStartNumber = 1
+            if segment_template_from_adapt is not None:
+                fTimescale = (int)(segment_template_from_adapt.attrib.get('timescale', fTimescale))
+                fDuration = (int)(segment_template_from_adapt.attrib.get('duration', fDuration))
+                fStartNumber = (int)(segment_template_from_adapt.attrib.get('startNumber', fStartNumber))
+
             if segment_template is not None:
                 fTimescale = (int)(segment_template.attrib.get('timescale', fTimescale))
                 fDuration = (int)(segment_template.attrib.get('duration', fDuration))


### PR DESCRIPTION
…hin Representation 

```xml
<AdaptationSet id="0">
      <Representation bandwidth="800000" codecs="avc1.4D4028" height="480" id="1" mimeType="video/mp4" width="854">
        <BaseURL>filename-480x854.mp4</BaseURL>
        <SegmentBase indexRange="1014-1201" timescale="24000">
          <Initialization range="0-1013"/>
        </SegmentBase>
      </Representation>
```


Not able to provide an mpd, but encountered mpds which do not use SegmentTemplate but BaseURL with the path/filename within the AdaptationSet.  